### PR TITLE
improve:优化计时器逻辑

### DIFF
--- a/Ink Canvas/Windows/NewStyleMinimizedTimerWindow.xaml.cs
+++ b/Ink Canvas/Windows/NewStyleMinimizedTimerWindow.xaml.cs
@@ -63,6 +63,7 @@ namespace Ink_Canvas.Windows
                 if (!IsVisible) return;
                 if (_shouldHide != null && _shouldHide())
                 {
+                    _restoreCallback?.Invoke();
                     Close();
                     return;
                 }


### PR DESCRIPTION
# 问题
当计时器结束且最小化独立窗口关闭后主窗口不会显示 , 但如果计时器结束时显示的是主窗口，主窗口保持显示 ，两次行为不一致
# 修复内容
当透明小窗口因计时结束关闭时打开计时主窗口，即在透明小窗口的`UpdateTimer_Elapsed`函数内将主窗口显示