### PR TITLE
chore: centralize Nerdbank.GitVersioning to Directory.Build.props (3.10.94)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,14 +2,16 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <NBGV_CacheMode>None</NBGV_CacheMode>
-    <!-- 标记：仓库树内已由本文件统一注入 Nerdbank.GitVersioning。
+    <!-- 仓库中的所有项目均从此处使用同一版 Nerdbank.GitVersioning，避免项目文件对导入的
+         PackageReference 使用 Update；该组合会使 NuGet restore 在部分 SDK 版本中失败。
+         标记：仓库树内已由本文件统一注入 Nerdbank.GitVersioning。
          需要自包含引用 NBGV 的项目（如 InkCanvas.PluginSdk，供独立构建场景使用）用此属性避免重复引用产生 NU1504。 -->
     <NBGVProvidedByDirectoryBuildProps>true</NBGVProvidedByDirectoryBuildProps>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>
-      <Version>3.9.50</Version>
+      <Version>3.10.94</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Ink Canvas/InkCanvasForClass.csproj
+++ b/Ink Canvas/InkCanvasForClass.csproj
@@ -650,10 +650,6 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.10.94" />
-  </ItemGroup>
-  
   <Target Name="SetAssemblyInformationalVersion" DependsOnTargets="GetBuildVersion" AfterTargets="GetBuildVersion">
     <PropertyGroup>
       <!-- 如果没有GitCommitIdShort，就置为UNKNOWN -->


### PR DESCRIPTION
### Motivation
- Prevent NuGet restore-time item mutation that can trigger null-reference failures in some SDK versions by avoiding per-project `PackageReference Update` usage for `Nerdbank.GitVersioning`.
- Ensure all SDK-style projects resolve the same NBGV version as reflected in the lock file to make restores reproducible across environments.

### Description
- Bumped the centralized `Nerdbank.GitVersioning` `Version` in `Directory.Build.props` from `3.9.50` to `3.10.94` and added a comment explaining why the package must be provided centrally.
- Removed the per-project `PackageReference Update="Nerdbank.GitVersioning"` entry from `Ink Canvas/InkCanvasForClass.csproj` so projects consume the central reference instead of mutating the import during restore.
- No other package versions were changed as part of this patch and the project file layout/targets were preserved.

### Testing
- Ran an XML/JSON verification script (`python3`) that confirmed `Directory.Build.props` now exposes `Nerdbank.GitVersioning` `3.10.94` and that `InkCanvasForClass.csproj` no longer contains a `PackageReference Update` entry, and the lock-file entry matches `3.10.94` (success).
- Ran basic repository checks (`git diff --check`) and a repository head verification (`git show --check`) which reported no check failures (success).
- Attempted to run `dotnet restore "Ink Canvas.sln" --locked-mode` but it was not executed because `dotnet` is not available in this environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d669f45048329a1ac122210dbb2da)